### PR TITLE
Fix: self route

### DIFF
--- a/lib/coordinator.js
+++ b/lib/coordinator.js
@@ -153,7 +153,45 @@ async function wire (interceptor, port, url, ready, address) {
     const url1 = key.replace(interceptor[kDomain], '').toLowerCase()
     const url2 = url.replace(interceptor[kDomain], '').toLowerCase()
 
-    if (url1 === url2) continue
+    if (url1 === url2) {
+      // Wire a loopback MessageChannel so a thread can reach its own
+      // hostname (i.e. a service calling itself). Both channel ends are
+      // registered in the same thread: a request dispatched out of one end
+      // is served by the wire handler listening on the other end.
+      // The messages are intentionally not awaited: the thread can only
+      // dispatch to itself once it has processed them, and MessagePort
+      // buffers messages until a listener is attached, so no request can
+      // be lost. Awaiting here would also delay the ready hook and let a
+      // pending wire() resolve a later route() registration prematurely.
+      if (!roundRobin.ports.includes(port)) continue
+
+      if (wired) {
+        port.postMessage({
+          type: MESSAGE_ROUTE_UPDATE,
+          url,
+          ready: port[kReady],
+          threadId: port[kThread],
+          address: port[kAddress]
+        })
+        continue
+      }
+
+      const { port1, port2 } = new MessageChannel()
+      for (const loopbackPort of [port1, port2]) {
+        port.postMessage(
+          {
+            type: MESSAGE_ROUTE_ADD,
+            url: url2,
+            port: loopbackPort,
+            ready: port[kReady],
+            address: port[kAddress],
+            threadId: port[kThread]
+          },
+          [loopbackPort]
+        )
+      }
+      continue
+    }
 
     const isAllowed = interceptor[kHooks].fireOnChannelCreation(url1, url2)
     if (isAllowed === false) continue

--- a/lib/coordinator.js
+++ b/lib/coordinator.js
@@ -15,6 +15,7 @@ const {
   kDomain,
   kHooks,
   kInflightOutgoing,
+  kLoopback,
   kOnError,
   kOnReadyHook,
   kReady,
@@ -163,9 +164,14 @@ async function wire (interceptor, port, url, ready, address) {
       // buffers messages until a listener is attached, so no request can
       // be lost. Awaiting here would also delay the ready hook and let a
       // pending wire() resolve a later route() registration prematurely.
-      if (!roundRobin.ports.includes(port)) continue
+      if (!roundRobin.has(port)) continue
 
-      if (wired) {
+      // Create the loopback only once per (port, hostname): re-wiring the
+      // same port (e.g. when it is registered under an additional hostname)
+      // must not add duplicate loopback channels. An existing loopback only
+      // needs its ready state refreshed.
+      port[kLoopback] ??= new Set()
+      if (wired || port[kLoopback].has(key)) {
         port.postMessage({
           type: MESSAGE_ROUTE_UPDATE,
           url,
@@ -175,6 +181,7 @@ async function wire (interceptor, port, url, ready, address) {
         })
         continue
       }
+      port[kLoopback].add(key)
 
       const { port1, port2 } = new MessageChannel()
       for (const loopbackPort of [port1, port2]) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,6 +70,7 @@ module.exports = {
   debug: debuglog('undici-thread-interceptor').bind(null, `currentThread: ${threadId}`),
   kAddress: Symbol('undici-thread-interceptor.address'),
   kWired: Symbol('undici-thread-interceptor.wired'),
+  kLoopback: Symbol('undici-thread-interceptor.loopback'),
   kReady: Symbol('undici-thread-interceptor.ready'),
   kClosed: Symbol('undici-thread-interceptor.closed'),
   kDomain: Symbol('undici-thread-interceptor.domain'),

--- a/test/fixtures/self.js
+++ b/test/fixtures/self.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { parentPort } = require('worker_threads')
+const fastify = require('fastify')
+const { wire } = require('../../')
+const { request } = require('undici')
+
+const app = fastify()
+
+wire({ server: app, port: parentPort, domain: '.local' })
+
+app.get('/ping', async function () {
+  return { pong: true }
+})
+
+app.get('/self', async function () {
+  const { statusCode, body } = await request('http://myself.local/ping')
+  return { statusCode, response: await body.json() }
+})

--- a/test/self-route.test.js
+++ b/test/self-route.test.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const { deepStrictEqual } = require('node:assert')
+const { join } = require('node:path')
+const { test } = require('node:test')
+const { Worker } = require('node:worker_threads')
+const { createThreadInterceptor } = require('../')
+const { Agent, request } = require('undici')
+
+test('a thread can request its own hostname', async t => {
+  const worker = new Worker(join(__dirname, 'fixtures', 'self.js'))
+  t.after(() => worker.terminate())
+
+  const interceptor = createThreadInterceptor({ domain: '.local' })
+  await interceptor.route('myself', worker)
+
+  const agent = new Agent().compose(interceptor)
+
+  const { statusCode, body } = await request('http://myself.local/self', { dispatcher: agent })
+  deepStrictEqual(statusCode, 200)
+  deepStrictEqual(await body.json(), { statusCode: 200, response: { pong: true } })
+})
+
+test('a thread can request its own hostname when multiple threads serve it', async t => {
+  const worker1 = new Worker(join(__dirname, 'fixtures', 'self.js'))
+  t.after(() => worker1.terminate())
+
+  const worker2 = new Worker(join(__dirname, 'fixtures', 'self.js'))
+  t.after(() => worker2.terminate())
+
+  const interceptor = createThreadInterceptor({ domain: '.local' })
+  await interceptor.route('myself', worker1)
+  await interceptor.route('myself', worker2)
+
+  const agent = new Agent().compose(interceptor)
+
+  // Exercise the round-robin: every request must succeed regardless of
+  // whether it lands on the caller itself or on the sibling thread.
+  for (let i = 0; i < 4; i++) {
+    const { statusCode, body } = await request('http://myself.local/self', { dispatcher: agent })
+    deepStrictEqual(statusCode, 200)
+    deepStrictEqual(await body.json(), { statusCode: 200, response: { pong: true } })
+  }
+})


### PR DESCRIPTION
The coordinator never wired a thread to its own hostname, so a request to the thread's own url failed with "No target found".

In our case we have a shared plugin that integrates with one of the modules in our Platformatic modulith through a generated HTTP client. The plugin is registered in several services, including the one the client targets. this change makes it work there too, instead of failing with "No target found".

Why not use Platformatic messaging instead? We want to keep each module movable: an HTTP client works unchanged whether the target module lives in the same runtime or is later split out into its own deployment, while messaging only exists inside the runtime.