### PR TITLE
fix: close orphaned response body ports

### DIFF
--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -92,6 +92,7 @@ interface PendingRequest {
   onMessage: (value: unknown) => void
   pauseResponse?: () => void
   resumeResponse?: () => void
+  abortResponse?: (reason: Error) => void
 }
 
 interface Peer {
@@ -414,6 +415,7 @@ export class Interceptor {
         abort (reason: Error) {
           this.aborted = true
           this.reason = reason
+          pending.abortResponse?.(reason)
         },
         pause () {
           this.paused = true
@@ -1064,6 +1066,12 @@ export class Interceptor {
 
     const pending = peer.pending.get(message.id)
     if (!pending) {
+      // A response that arrives after its request timed out has no consumer:
+      // close its body port so the sending side can release buffered data.
+      if (message.type === Message.RESPONSE) {
+        const { bodyPort } = value as ResponseMessage
+        bodyPort?.close()
+      }
       return
     }
 
@@ -1097,6 +1105,7 @@ export class Interceptor {
 
     try {
       if (pending.controller.aborted) {
+        response.bodyPort?.close()
         pending.handler.onResponseError?.(pending.controller, pending.controller.reason as Error)
         pending.resolve()
         return
@@ -1110,11 +1119,13 @@ export class Interceptor {
       )
 
       if (pending.controller.aborted) {
+        response.bodyPort?.close()
         pending.handler.onResponseError?.(pending.controller, pending.controller.reason as Error)
         pending.resolve()
         return
       }
     } catch (error) {
+      response.bodyPort?.close()
       this.#publishRequestError(pending.request, pending.context, error as Error)
       pending.handler.onResponseError?.(pending.controller, error as Error)
       pending.resolve()
@@ -1125,6 +1136,11 @@ export class Interceptor {
       const body = new MessagePortReadable({ port: response.bodyPort })
       pending.pauseResponse = () => body.pause()
       pending.resumeResponse = () => body.resume()
+      pending.abortResponse = reason => {
+        // Tear down the body stream: this notifies the sending side and
+        // closes the port, so buffered data can be released.
+        body.destroy(reason)
+      }
 
       body.on('data', chunk => {
         try {
@@ -1138,6 +1154,10 @@ export class Interceptor {
       })
 
       body.on('end', () => {
+        // The body is complete: a later abort must not tear down a stream whose
+        // terminal event was already delivered.
+        pending.abortResponse = undefined
+
         try {
           pending.handler.onResponseEnd?.(pending.controller as any, {})
         } catch (error) {

--- a/src/message-port-streams.ts
+++ b/src/message-port-streams.ts
@@ -8,6 +8,16 @@ interface StreamControl {
   err?: Error
 }
 
+function postControl (port: MessagePort, control: StreamControl): void {
+  try {
+    port.postMessage(control)
+  } catch {
+    // A destroy reason that cannot be structured-cloned must not prevent the
+    // teardown: the port is closed right after, and the other side reacts to
+    // that instead.
+  }
+}
+
 export class MessagePortWritable extends Writable {
   messagePort: MessagePort
   #callback: ((error?: Error | null) => void) | null
@@ -49,7 +59,7 @@ export class MessagePortWritable extends Writable {
 
   _destroy (err: Error | null, callback: (error?: Error | null) => void): void {
     if (!this.#otherSideDestroyed) {
-      this.messagePort.postMessage(err ? { err } : { fin: true })
+      postControl(this.messagePort, err ? { err } : { fin: true })
     }
 
     setImmediate(() => {
@@ -147,9 +157,9 @@ export class MessagePortDuplex extends Duplex {
   _destroy (err: Error | null, callback: (error?: Error | null) => void): void {
     if (!this.#otherSideDestroyed) {
       if (err) {
-        this.messagePort.postMessage({ err })
+        postControl(this.messagePort, { err })
       } else if (!this.#finSent) {
-        this.messagePort.postMessage({ fin: true })
+        postControl(this.messagePort, { fin: true })
       }
     }
 
@@ -198,7 +208,7 @@ export class MessagePortReadable extends Readable {
 
   _destroy (err: Error | null, callback: (error?: Error | null) => void): void {
     if (err && !this.#otherSideDestroyed) {
-      this.messagePort.postMessage({ err })
+      postControl(this.messagePort, { err })
     }
 
     setImmediate(() => {

--- a/test/resilience.test.ts
+++ b/test/resilience.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual, rejects, strictEqual } from 'node:assert'
+import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert'
 import { once } from 'node:events'
 import { Readable } from 'node:stream'
 import { test } from 'node:test'
@@ -562,4 +562,241 @@ test('interceptor ignores peer messages without matching pending requests', asyn
     channel.port2.postMessage({ err: new Error('stream body failed') })
     await remoteErrorDone.promise
   }
+})
+
+test('closes orphaned response body ports so the sender can release buffered data', async t => {
+  const meshId = directMeshId('orphaned-body-ports')
+  const coordinator = createCoordinator({ meshId })
+  t.after(() => coordinator.destroy())
+
+  const serverChannel = new MessageChannel()
+  coordinator.connectMember({
+    type: Message.COORDINATOR_CONNECT,
+    meshId,
+    role: 'server',
+    threadId,
+    port: serverChannel.port1,
+    server: {
+      id: 'server-1',
+      origin: 'http:orphaned.local',
+      state: 'available',
+      mode: 'thread'
+    }
+  } as CoordinatorConnectMessage)
+  t.after(() => serverChannel.port2.close())
+
+  async function createInterceptor (connectTimeout?: number): Promise<Interceptor> {
+    const interceptor = new Interceptor({ meshId, domain: '.local', connectTimeout })
+    t.after(() => interceptor.close())
+    await interceptor.ready
+    await waitForServer(interceptor, 'http:orphaned.local')
+    return interceptor
+  }
+
+  // The peer channel is created lazily by the first dispatch, so this has to be
+  // called before dispatching, and each interceptor gets its own peer.
+  function connectPeer (interceptor: Interceptor): Promise<MessagePort> {
+    const peerReady = Promise.withResolvers<MessagePort>()
+    const onWorkerMessage = (value: unknown) => {
+      const message = value as { type?: Message; interceptorId?: string; port?: MessagePort }
+      if (
+        message.type === Message.PEER_CONNECT &&
+        message.interceptorId === interceptor.interceptorId &&
+        message.port
+      ) {
+        message.port.start()
+        peerReady.resolve(message.port)
+      }
+    }
+    process.on('workerMessage', onWorkerMessage)
+    t.after(() => process.off('workerMessage', onWorkerMessage))
+
+    return peerReady.promise.then(peer => {
+      t.after(() => peer.close())
+      return peer
+    })
+  }
+
+  const request = { origin: 'http://orphaned.local', path: '/', method: 'GET', headers: {} }
+  const sources: Readable[] = []
+  // A scenario that fails would otherwise leave its orphaned channel open, which
+  // keeps the event loop alive and turns a red test into a hanging one.
+  t.after(() => {
+    for (const source of sources) {
+      source.destroy()
+    }
+  })
+
+  // Each scenario streams the response body from a source that never ends: the
+  // sender keeps buffering until the receiving side tears the port down, so the
+  // source being destroyed is the observable proof that teardown propagated.
+  function orphanedBody (): {
+    sourceClosed: Promise<unknown>
+    transferable: ReturnType<typeof MessagePortWritable.asTransferable>
+  } {
+    const source = new Readable({ read () {} })
+    source.push('never delivered')
+    // The teardown destroys the source with an error: swallow it and observe
+    // 'close', which fires in both the error and the plain-close paths.
+    source.on('error', () => {})
+    sources.push(source)
+    const sourceClosed = requestWithTimeout(new Promise<void>(resolve => source.once('close', resolve)), 2000)
+    const transferable = MessagePortWritable.asTransferable(source)
+    return { sourceClosed, transferable }
+  }
+
+  {
+    // A response that arrives after the request timed out has no consumer. Only
+    // this scenario wants a short connectTimeout: for the other two it would be
+    // a deadline on the whole round trip, and a slow run would fail them.
+    const interceptor = await createInterceptor(100)
+    const peerConnected = connectPeer(interceptor)
+
+    const timedOut = Promise.withResolvers<void>()
+    interceptor.dispatch(() => false, { ...request } as any, {
+      onResponseError (_controller: any, error: Error) {
+        ok(error instanceof ConnectTimeoutError)
+        timedOut.resolve()
+      }
+    })
+
+    const peer = await peerConnected
+    const [lateRequest] = (await once(peer, 'message')) as Array<{ id: string }>
+    await requestWithTimeout(timedOut.promise, 2000)
+
+    const { sourceClosed, transferable } = orphanedBody()
+    peer.postMessage(
+      { type: Message.RESPONSE, id: lateRequest.id, statusCode: 200, headers: {}, bodyPort: transferable.port },
+      transferable.transferList
+    )
+    await sourceClosed
+  }
+
+  const interceptor = await createInterceptor()
+  const peerConnected = connectPeer(interceptor)
+
+  {
+    // A response for a request that was aborted before the body started.
+    const aborted = Promise.withResolvers<void>()
+    interceptor.dispatch(() => false, { ...request } as any, {
+      onRequestStart (controller: any) {
+        controller.abort(new Error('aborted before response'))
+      },
+      onResponseError (_controller: any, error: Error) {
+        strictEqual(error.message, 'aborted before response')
+        aborted.resolve()
+      }
+    })
+
+    const peer = await peerConnected
+    const [abortedRequest] = (await once(peer, 'message')) as Array<{ id: string }>
+
+    const { sourceClosed, transferable } = orphanedBody()
+    peer.postMessage(
+      { type: Message.RESPONSE, id: abortedRequest.id, statusCode: 200, headers: {}, bodyPort: transferable.port },
+      transferable.transferList
+    )
+    await sourceClosed
+    await requestWithTimeout(aborted.promise, 2000)
+  }
+
+  {
+    // An abort while the body is streaming must tear the stream down.
+    const errored = Promise.withResolvers<void>()
+    interceptor.dispatch(() => false, { ...request } as any, {
+      onResponseData (controller: any) {
+        controller.abort(new Error('aborted mid-stream'))
+      },
+      onResponseError (_controller: any, error: Error) {
+        strictEqual(error.message, 'aborted mid-stream')
+        errored.resolve()
+      }
+    })
+
+    const peer = await peerConnected
+    const [streamedRequest] = (await once(peer, 'message')) as Array<{ id: string }>
+
+    const { sourceClosed, transferable } = orphanedBody()
+    peer.postMessage(
+      { type: Message.RESPONSE, id: streamedRequest.id, statusCode: 200, headers: {}, bodyPort: transferable.port },
+      transferable.transferList
+    )
+    await requestWithTimeout(errored.promise, 2000)
+    await sourceClosed
+  }
+})
+
+test('closes the response body port when the abort reason cannot be cloned', async t => {
+  const meshId = directMeshId('non-cloneable-abort')
+  const coordinator = createCoordinator({ meshId })
+  t.after(() => coordinator.destroy())
+
+  const serverChannel = new MessageChannel()
+  coordinator.connectMember({
+    type: Message.COORDINATOR_CONNECT,
+    meshId,
+    role: 'server',
+    threadId,
+    port: serverChannel.port1,
+    server: {
+      id: 'server-1',
+      origin: 'http:non-cloneable.local',
+      state: 'available',
+      mode: 'thread'
+    }
+  } as CoordinatorConnectMessage)
+  t.after(() => serverChannel.port2.close())
+
+  const interceptor = new Interceptor({ meshId, domain: '.local' })
+  t.after(() => interceptor.close())
+  await interceptor.ready
+  await waitForServer(interceptor, 'http:non-cloneable.local')
+
+  const peerReady = Promise.withResolvers<MessagePort>()
+  const onWorkerMessage = (value: unknown) => {
+    const message = value as { type?: Message; interceptorId?: string; port?: MessagePort }
+    if (message.type === Message.PEER_CONNECT && message.interceptorId === interceptor.interceptorId && message.port) {
+      message.port.start()
+      peerReady.resolve(message.port)
+    }
+  }
+  process.on('workerMessage', onWorkerMessage)
+  t.after(() => process.off('workerMessage', onWorkerMessage))
+
+  // Abort reasons come from the caller and are not always structured-cloneable:
+  // failing to forward one must not leave the port, and the buffered body
+  // behind it, alive.
+  const reason = new Error('aborted with an unclonable reason', { cause: { notCloneable: () => {} } })
+  const errored = Promise.withResolvers<void>()
+  interceptor.dispatch(
+    () => false,
+    { origin: 'http://non-cloneable.local', path: '/', method: 'GET', headers: {} } as any,
+    {
+      onResponseData (controller: any) {
+        controller.abort(reason)
+      },
+      onResponseError () {
+        errored.resolve()
+      }
+    }
+  )
+
+  const peer = await peerReady.promise
+  t.after(() => peer.close())
+  const [streamedRequest] = (await once(peer, 'message')) as Array<{ id: string }>
+
+  const source = new Readable({ read () {} })
+  source.push('never delivered')
+  source.on('error', () => {})
+  t.after(() => source.destroy())
+  const sourceClosed = requestWithTimeout(new Promise<void>(resolve => source.once('close', resolve)), 2000)
+  const transferable = MessagePortWritable.asTransferable(source)
+
+  peer.postMessage(
+    { type: Message.RESPONSE, id: streamedRequest.id, statusCode: 200, headers: {}, bodyPort: transferable.port },
+    transferable.transferList
+  )
+
+  await requestWithTimeout(errored.promise, 2000)
+  await sourceClosed
 })

--- a/test/resilience.test.ts
+++ b/test/resilience.test.ts
@@ -1,7 +1,7 @@
 import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert'
 import { once } from 'node:events'
 import { Readable } from 'node:stream'
-import { test } from 'node:test'
+import { test, type TestContext } from 'node:test'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { MessageChannel, threadId, type MessagePort } from 'node:worker_threads'
 import { Agent, interceptors, request } from 'undici'
@@ -585,7 +585,7 @@ test('closes orphaned response body ports so the sender can release buffered dat
   } as CoordinatorConnectMessage)
   t.after(() => serverChannel.port2.close())
 
-  async function createInterceptor (connectTimeout?: number): Promise<Interceptor> {
+  async function createInterceptor (t: TestContext, connectTimeout?: number): Promise<Interceptor> {
     const interceptor = new Interceptor({ meshId, domain: '.local', connectTimeout })
     t.after(() => interceptor.close())
     await interceptor.ready
@@ -595,7 +595,7 @@ test('closes orphaned response body ports so the sender can release buffered dat
 
   // The peer channel is created lazily by the first dispatch, so this has to be
   // called before dispatching, and each interceptor gets its own peer.
-  function connectPeer (interceptor: Interceptor): Promise<MessagePort> {
+  function connectPeer (t: TestContext, interceptor: Interceptor): Promise<MessagePort> {
     const peerReady = Promise.withResolvers<MessagePort>()
     const onWorkerMessage = (value: unknown) => {
       const message = value as { type?: Message; interceptorId?: string; port?: MessagePort }
@@ -618,19 +618,11 @@ test('closes orphaned response body ports so the sender can release buffered dat
   }
 
   const request = { origin: 'http://orphaned.local', path: '/', method: 'GET', headers: {} }
-  const sources: Readable[] = []
-  // A scenario that fails would otherwise leave its orphaned channel open, which
-  // keeps the event loop alive and turns a red test into a hanging one.
-  t.after(() => {
-    for (const source of sources) {
-      source.destroy()
-    }
-  })
 
-  // Each scenario streams the response body from a source that never ends: the
+  // Each subtest streams the response body from a source that never ends: the
   // sender keeps buffering until the receiving side tears the port down, so the
   // source being destroyed is the observable proof that teardown propagated.
-  function orphanedBody (): {
+  function orphanedBody (t: TestContext): {
     sourceClosed: Promise<unknown>
     transferable: ReturnType<typeof MessagePortWritable.asTransferable>
   } {
@@ -639,18 +631,19 @@ test('closes orphaned response body ports so the sender can release buffered dat
     // The teardown destroys the source with an error: swallow it and observe
     // 'close', which fires in both the error and the plain-close paths.
     source.on('error', () => {})
-    sources.push(source)
+    // A subtest that fails would otherwise leave its orphaned channel open,
+    // which keeps the event loop alive and turns a red test into a hanging one.
+    t.after(() => source.destroy())
     const sourceClosed = requestWithTimeout(new Promise<void>(resolve => source.once('close', resolve)), 2000)
     const transferable = MessagePortWritable.asTransferable(source)
     return { sourceClosed, transferable }
   }
 
-  {
-    // A response that arrives after the request timed out has no consumer. Only
-    // this scenario wants a short connectTimeout: for the other two it would be
-    // a deadline on the whole round trip, and a slow run would fail them.
-    const interceptor = await createInterceptor(100)
-    const peerConnected = connectPeer(interceptor)
+  await t.test('a response that arrives after the request timed out has no consumer', async t => {
+    // Only this subtest wants a short connectTimeout: for the other two it would
+    // be a deadline on the whole round trip, and a slow run would fail them.
+    const interceptor = await createInterceptor(t, 100)
+    const peerConnected = connectPeer(t, interceptor)
 
     const timedOut = Promise.withResolvers<void>()
     interceptor.dispatch(() => false, { ...request } as any, {
@@ -664,19 +657,18 @@ test('closes orphaned response body ports so the sender can release buffered dat
     const [lateRequest] = (await once(peer, 'message')) as Array<{ id: string }>
     await requestWithTimeout(timedOut.promise, 2000)
 
-    const { sourceClosed, transferable } = orphanedBody()
+    const { sourceClosed, transferable } = orphanedBody(t)
     peer.postMessage(
       { type: Message.RESPONSE, id: lateRequest.id, statusCode: 200, headers: {}, bodyPort: transferable.port },
       transferable.transferList
     )
     await sourceClosed
-  }
+  })
 
-  const interceptor = await createInterceptor()
-  const peerConnected = connectPeer(interceptor)
+  await t.test('a response for a request that was aborted before the body started', async t => {
+    const interceptor = await createInterceptor(t)
+    const peerConnected = connectPeer(t, interceptor)
 
-  {
-    // A response for a request that was aborted before the body started.
     const aborted = Promise.withResolvers<void>()
     interceptor.dispatch(() => false, { ...request } as any, {
       onRequestStart (controller: any) {
@@ -691,17 +683,19 @@ test('closes orphaned response body ports so the sender can release buffered dat
     const peer = await peerConnected
     const [abortedRequest] = (await once(peer, 'message')) as Array<{ id: string }>
 
-    const { sourceClosed, transferable } = orphanedBody()
+    const { sourceClosed, transferable } = orphanedBody(t)
     peer.postMessage(
       { type: Message.RESPONSE, id: abortedRequest.id, statusCode: 200, headers: {}, bodyPort: transferable.port },
       transferable.transferList
     )
     await sourceClosed
     await requestWithTimeout(aborted.promise, 2000)
-  }
+  })
 
-  {
-    // An abort while the body is streaming must tear the stream down.
+  await t.test('an abort while the body is streaming tears the stream down', async t => {
+    const interceptor = await createInterceptor(t)
+    const peerConnected = connectPeer(t, interceptor)
+
     const errored = Promise.withResolvers<void>()
     interceptor.dispatch(() => false, { ...request } as any, {
       onResponseData (controller: any) {
@@ -716,87 +710,42 @@ test('closes orphaned response body ports so the sender can release buffered dat
     const peer = await peerConnected
     const [streamedRequest] = (await once(peer, 'message')) as Array<{ id: string }>
 
-    const { sourceClosed, transferable } = orphanedBody()
+    const { sourceClosed, transferable } = orphanedBody(t)
     peer.postMessage(
       { type: Message.RESPONSE, id: streamedRequest.id, statusCode: 200, headers: {}, bodyPort: transferable.port },
       transferable.transferList
     )
     await requestWithTimeout(errored.promise, 2000)
     await sourceClosed
-  }
-})
+  })
 
-test('closes the response body port when the abort reason cannot be cloned', async t => {
-  const meshId = directMeshId('non-cloneable-abort')
-  const coordinator = createCoordinator({ meshId })
-  t.after(() => coordinator.destroy())
+  await t.test('an abort with a reason that cannot be structured-cloned', async t => {
+    const interceptor = await createInterceptor(t)
+    const peerConnected = connectPeer(t, interceptor)
 
-  const serverChannel = new MessageChannel()
-  coordinator.connectMember({
-    type: Message.COORDINATOR_CONNECT,
-    meshId,
-    role: 'server',
-    threadId,
-    port: serverChannel.port1,
-    server: {
-      id: 'server-1',
-      origin: 'http:non-cloneable.local',
-      state: 'available',
-      mode: 'thread'
-    }
-  } as CoordinatorConnectMessage)
-  t.after(() => serverChannel.port2.close())
-
-  const interceptor = new Interceptor({ meshId, domain: '.local' })
-  t.after(() => interceptor.close())
-  await interceptor.ready
-  await waitForServer(interceptor, 'http:non-cloneable.local')
-
-  const peerReady = Promise.withResolvers<MessagePort>()
-  const onWorkerMessage = (value: unknown) => {
-    const message = value as { type?: Message; interceptorId?: string; port?: MessagePort }
-    if (message.type === Message.PEER_CONNECT && message.interceptorId === interceptor.interceptorId && message.port) {
-      message.port.start()
-      peerReady.resolve(message.port)
-    }
-  }
-  process.on('workerMessage', onWorkerMessage)
-  t.after(() => process.off('workerMessage', onWorkerMessage))
-
-  // Abort reasons come from the caller and are not always structured-cloneable:
-  // failing to forward one must not leave the port, and the buffered body
-  // behind it, alive.
-  const reason = new Error('aborted with an unclonable reason', { cause: { notCloneable: () => {} } })
-  const errored = Promise.withResolvers<void>()
-  interceptor.dispatch(
-    () => false,
-    { origin: 'http://non-cloneable.local', path: '/', method: 'GET', headers: {} } as any,
-    {
+    // Abort reasons come from the caller and are not always structured-cloneable:
+    // failing to forward one must not leave the port, and the buffered body
+    // behind it, alive.
+    const reason = new Error('aborted with an unclonable reason', { cause: { notCloneable: () => {} } })
+    const errored = Promise.withResolvers<void>()
+    interceptor.dispatch(() => false, { ...request } as any, {
       onResponseData (controller: any) {
         controller.abort(reason)
       },
       onResponseError () {
         errored.resolve()
       }
-    }
-  )
+    })
 
-  const peer = await peerReady.promise
-  t.after(() => peer.close())
-  const [streamedRequest] = (await once(peer, 'message')) as Array<{ id: string }>
+    const peer = await peerConnected
+    const [streamedRequest] = (await once(peer, 'message')) as Array<{ id: string }>
 
-  const source = new Readable({ read () {} })
-  source.push('never delivered')
-  source.on('error', () => {})
-  t.after(() => source.destroy())
-  const sourceClosed = requestWithTimeout(new Promise<void>(resolve => source.once('close', resolve)), 2000)
-  const transferable = MessagePortWritable.asTransferable(source)
-
-  peer.postMessage(
-    { type: Message.RESPONSE, id: streamedRequest.id, statusCode: 200, headers: {}, bodyPort: transferable.port },
-    transferable.transferList
-  )
-
-  await requestWithTimeout(errored.promise, 2000)
-  await sourceClosed
+    const { sourceClosed, transferable } = orphanedBody(t)
+    peer.postMessage(
+      { type: Message.RESPONSE, id: streamedRequest.id, statusCode: 200, headers: {}, bodyPort: transferable.port },
+      transferable.transferList
+    )
+    await requestWithTimeout(errored.promise, 2000)
+    await sourceClosed
+  })
 })


### PR DESCRIPTION
## The problem

A response body that is not inlined, meaning it has no known content-length or it is at least `MAX_BODY`, is transferred over a dedicated MessagePort (`MessagePortWritable.asTransferable` on the server side, `MessagePortReadable` on the interceptor side). When the response ends up with no consumer, nothing closes that port: the sending side keeps the port and its buffered chunks alive indefinitely, together with the retained request context. The memory involved is off the V8 heap (port queues and Buffer backing stores), so heap-based monitoring never sees it.

There are three paths where the consumer disappears:

1. **Late response after `connectTimeout`.** The timeout deletes the entry from `peer.pending` and rejects. When the response message arrives afterwards, `#onPeerMessage` finds no pending entry and silently drops it, leaving `bodyPort` open forever.
2. **Response for an already-aborted request.** Both `controller.aborted` early returns in `#handleResponse` (and the `catch` around `onResponseStart`) call `onResponseError` without closing `response.bodyPort`.
3. **Abort while the body is streaming.** `controller.abort()` only sets a flag, so neither the `MessagePortReadable` nor the port is ever torn down and the sender keeps pushing into the port queue.

## The fix

Mostly local to `src/interceptor.ts` (+20 lines):

- `#onPeerMessage`: when a `RESPONSE` arrives with no matching pending entry, close its `bodyPort`.
- `#handleResponse`: close `response.bodyPort` in both aborted branches and in the `catch` branch.
- Streaming abort: a new optional `abortResponse` callback on `PendingRequest` (same pattern as the existing `pauseResponse` and `resumeResponse`), invoked by `controller.abort()`, destroys the body stream with the abort reason. The destroy notifies the sending side through the existing `{err}` control message and closes the port, so the sender's pipeline tears down the source stream and releases the buffered data. It is cleared once the body ends, so a late abort cannot follow `onResponseEnd` with an `onResponseError`.

One supporting change in `src/message-port-streams.ts`: `_destroy` posted the control message before scheduling the port close, so a reason that cannot be structured cloned threw and the close never happened. Abort reasons come from the caller, which makes that reachable from the path above and would have reintroduced the very leak this fixes. Forwarding the reason is best effort now; the port is closed either way and the other side falls back to reacting to the close.

No behavior change for consumed responses: the full suite passes unchanged.

## Tests

Two new tests in `test/resilience.test.ts` using the existing fake peer harness. The first covers the three orphaning paths (late response, abort before the body starts, abort mid stream); the second aborts with a reason that cannot be structured cloned. The assertion is intentionally on the sending side: the source `Readable` behind `MessagePortWritable.asTransferable` must be destroyed, which proves the teardown propagated across the port and the buffered data was actually released. Each scenario fails without its corresponding fix, verified by reverting the hunks one at a time.

## How we hit this in production

We run this library through `@platformatic/runtime` (which currently consumes the 1.x line, where the same leak paths exist). Under load, our gateway service showed unbounded external memory growth: roughly 48 MB/min that kept growing after traffic stopped, heap flat the whole time, ending in a container OOM kill. Allocation profiles taken during the runaway pointed at Buffers pushed by `message-port-streams` and at request contexts retained by responses that never completed, which is what led us to these three paths.

We then shipped the equivalent fix to our staging environment as a pnpm patch on 1.4.0 and measured before and after under the same load profile (about 115 page loads in 12 minutes against our admin UI, then all traffic stopped, sampling the runtime's Prometheus endpoint every 60s):

- **Before:** external memory kept growing after traffic stopped, +541 MB over the following 15 minutes (about 65 MB/min, monotonic), with the process wide MessagePort count stuck at 794 for the whole window. Peak RSS 3746 MB.
- **After:** no post traffic growth at all (flat between 507 and 517 MB, noise level), MessagePort count back to its 572 baseline within 2 minutes of stopping, and it never moved again even under a confirmation burst of 31 requests/min. Peak RSS 3370 MB, and the gateway service's own external memory stayed in its fresh boot band (20 to 32 MB) across all 55 samples.

One note on attribution, for honesty: an unrelated internal change (routing internal dispatch directly to services instead of through our gateway) landed between the two measurements and shares credit on the total memory axis. The MessagePort axis isolates this patch: user requests aborted mid flight are not affected by that routing change, and the port ratchet is exactly what disappeared.

## 1.x backport

`@platformatic/runtime` consumes the 1.x line (`^1.3.1` at 3.63.0), where the same defects exist in `lib/wire.js`, `lib/coordinator.js`, `lib/dispatch-controller.js`, `lib/interceptor.js` and `lib/message-port-streams.js`. This is not limited to older releases: `git diff v1.4.0 v1.5.0` touches only workflows, `.gitignore` and the manifests, so the latest 1.x ships byte identical library code and every path above is still open there.

We currently carry this fix as a local pnpm patch. If you are open to it, we would be happy to send the equivalent patch against 1.5.x so it can ship as a 1.5.1: that would let every current Platformatic user pick it up without waiting for the v2 migration.
