### PR TITLE
fix: do not stall on targets whose thread has already exited

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -2,7 +2,7 @@
 
 const { RoundRobin } = require('./roundrobin')
 const { RequestsStore } = require('./requests-store')
-const { kAddress, kReady, kDomain, kInflightOutgoing, kRoutes, kThread } = require('./utils')
+const { kAddress, kReady, kDomain, kInflightOutgoing, kOnReadyHook, kRoutes, kTerminated, kThread } = require('./utils')
 
 function normalizeUrl (interceptor, url) {
   const domain = interceptor[kDomain]
@@ -16,6 +16,14 @@ function normalizeUrl (interceptor, url) {
 }
 
 function onClose (interceptor, port, url) {
+  // Record the terminal state: the 'exit' and 'close' events are emitted only
+  // once, so any later wait for a message from this target must not arm a timer.
+  port[kTerminated] = true
+
+  // Unblock any pending wire handshake, the target can no longer reply to it.
+  port[kOnReadyHook]?.()
+  port[kOnReadyHook] = null
+
   const routes = interceptor[kRoutes]
 
   const roundRobin = routes.get(url)

--- a/lib/coordinator.js
+++ b/lib/coordinator.js
@@ -10,6 +10,7 @@ const {
 } = require('./common')
 const {
   debug,
+  isTargetGone,
   kAddress,
   kClosed,
   kDomain,
@@ -110,6 +111,10 @@ async function addRoute (interceptor, url, ports) {
   const promises = []
 
   for (const port of ports) {
+    // A target whose thread is already gone can never reply to the wire
+    // handshake, so it is treated as already closed and not added to the mesh.
+    if (isTargetGone(port)) continue
+
     const added = commonAddRoute(interceptor, url, port, onCoordinatorMessage)
     if (!added) continue
 
@@ -317,7 +322,8 @@ async function removeThreadRoutes (interceptor, threadId) {
         port[kOnReadyHook] = null
         continue
       }
-      if (port[kWired]) {
+      // Ports whose thread is already gone cannot acknowledge the removal
+      if (port[kWired] && !isTargetGone(port)) {
         otherPorts.add(port)
       }
     }
@@ -353,10 +359,26 @@ async function close (interceptor) {
     }
   }
 
+  const seen = new Set()
+  const promises = []
+
+  // All the ports are closed in parallel so that a single unreachable target
+  // cannot delay or prevent the closing of the rest of the mesh.
   for (const [url, port] of ports) {
     /* c8 ignore next 4 - This is hard to test but under high load it might happen */
     // If the port has been removed in the meanwhile, skip it
     if (!routes.get(url)?.ports?.includes(port)) {
+      continue
+    }
+
+    // The same port can be registered under multiple hostnames, close it once
+    if (seen.has(port)) {
+      continue
+    }
+    seen.add(port)
+
+    // A target whose thread is already gone is considered already closed
+    if (isTargetGone(port)) {
       continue
     }
 
@@ -368,7 +390,17 @@ async function close (interceptor) {
 
     port.postMessage({ type: MESSAGE_CLOSE })
 
-    await closedPromise
+    promises.push(closedPromise)
+  }
+
+  const results = await Promise.allSettled(promises)
+
+  // Report the first failure, but only after all the other targets had the
+  // chance to close.
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      throw result.reason
+    }
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,6 +20,16 @@ class ThreadInterceptorError extends Error {
   }
 }
 
+const kTerminated = Symbol('undici-thread-interceptor.terminated')
+
+// Node.js emits 'exit' on a Worker exactly once and then removes all its
+// listeners, so a listener attached after the thread is gone will never fire.
+// Detect the terminal state upfront, otherwise waiting for a message from such
+// a target can only end up in a timeout.
+function isTargetGone (target) {
+  return target[kTerminated] === true || target.threadId === -1
+}
+
 function waitMessage (target, options, test) {
   if (typeof options === 'function') {
     test = options
@@ -27,6 +37,12 @@ function waitMessage (target, options, test) {
   }
 
   return new Promise(function (resolve, reject) {
+    // The target is already gone, no reply can ever arrive.
+    if (isTargetGone(target)) {
+      resolve(null)
+      return
+    }
+
     let timeout = null
 
     if (options.timeout) {
@@ -82,6 +98,7 @@ module.exports = {
   kInflightOutgoing: Symbol('undici-thread-interceptor.inflight.outgoing'),
   kRoutes: Symbol('undici-thread-interceptor.routes'),
   kServer: Symbol('undici-thread-interceptor.server'),
+  kTerminated,
   kThread: Symbol('undici-thread-interceptor.thread'),
   kTimeout: Symbol('undici-thread-interceptor.timeout'),
   kQueue: Symbol('undici-thread-interceptor.queue'),
@@ -99,6 +116,7 @@ module.exports = {
   MESSAGE_ROUTE_ADDED: 'undici-thread-interceptor.route.added',
   MESSAGE_ROUTE_REMOVED: 'undici-thread-interceptor.route.removed',
   MESSAGE_ROUTE_UPDATED: 'undici-thread-interceptor.route.updated',
+  isTargetGone,
   waitMessage,
   ThreadInterceptorError
 }

--- a/test/exited-worker.test.js
+++ b/test/exited-worker.test.js
@@ -1,0 +1,166 @@
+'use strict'
+
+const { test } = require('node:test')
+const { join } = require('node:path')
+const { once } = require('node:events')
+const { deepStrictEqual, ok, rejects, strictEqual } = require('node:assert')
+const { Worker } = require('node:worker_threads')
+const { Agent, request } = require('undici')
+const { createThreadInterceptor } = require('../')
+const { isTargetGone, waitMessage } = require('../lib/utils')
+
+// Simulate a worker which exited before the route cleanup listeners installed by
+// addRoute could run: the route is left in the mesh pointing at a dead thread.
+async function createStaleWorker (t, interceptor, url) {
+  const worker = new Worker(join(__dirname, 'fixtures', 'worker1.js'))
+  t.after(() => worker.terminate())
+
+  await interceptor.route(url, worker)
+
+  worker.removeAllListeners('exit')
+  worker.removeAllListeners('close')
+
+  await worker.terminate()
+  strictEqual(worker.threadId, -1)
+
+  return worker
+}
+
+test('close resolves promptly when a route points to an already exited worker', async t => {
+  const interceptor = createThreadInterceptor({ domain: '.local' })
+
+  await createStaleWorker(t, interceptor, 'stale')
+
+  const healthy = new Worker(join(__dirname, 'fixtures', 'worker1.js'))
+  t.after(() => healthy.terminate())
+  await interceptor.route('healthy', healthy)
+
+  const agent = new Agent().compose(interceptor)
+
+  {
+    const { statusCode, body } = await request('http://healthy.local', { dispatcher: agent })
+    strictEqual(statusCode, 200)
+    deepStrictEqual(await body.json(), { hello: 'world' })
+  }
+
+  const start = Date.now()
+  await interceptor.close()
+  const elapsed = Date.now() - start
+
+  ok(elapsed < 2000, `close() took ${elapsed}ms, it should not wait for the mesh timeout`)
+
+  // The healthy worker has been closed as well
+  await rejects(() => request('http://healthy.local', { dispatcher: agent }), {
+    message: 'No target found for healthy.local in thread 0.'
+  })
+})
+
+test('close still closes the other routes when one of them is unresponsive', async t => {
+  const unresponsive = new Worker(join(__dirname, 'fixtures', 'unresponsive-worker.js'), {
+    workerData: { blockMessageType: 'MESSAGE_CLOSE' }
+  })
+  t.after(() => unresponsive.terminate())
+
+  const healthy = new Worker(join(__dirname, 'fixtures', 'worker1.js'))
+  t.after(() => healthy.terminate())
+
+  const interceptor = createThreadInterceptor({ domain: '.local', meshTimeout: 1000 })
+
+  // The unresponsive worker is registered first, so with a serial close the
+  // healthy one would never receive MESSAGE_CLOSE.
+  await interceptor.route('unresponsive', unresponsive)
+  await interceptor.route('healthy', healthy)
+
+  const agent = new Agent().compose(interceptor)
+
+  await rejects(
+    interceptor.close(),
+    error => error.message.includes('Worker (threadId:') && error.message.includes('[MESSAGE_CLOSE]')
+  )
+
+  // The healthy worker has been closed anyway
+  await rejects(() => request('http://healthy.local', { dispatcher: agent }), {
+    message: 'No target found for healthy.local in thread 0.'
+  })
+})
+
+test('close sends a single MESSAGE_CLOSE to a worker registered under multiple hostnames', async t => {
+  const worker = new Worker(join(__dirname, 'fixtures', 'worker1.js'))
+  t.after(() => worker.terminate())
+
+  const interceptor = createThreadInterceptor({ domain: '.local' })
+
+  await interceptor.route('first', worker)
+  await interceptor.route('second', worker)
+
+  const agent = new Agent().compose(interceptor)
+
+  {
+    const { statusCode } = await request('http://second.local', { dispatcher: agent })
+    strictEqual(statusCode, 200)
+  }
+
+  const start = Date.now()
+  await interceptor.close()
+  const elapsed = Date.now() - start
+
+  ok(elapsed < 2000, `close() took ${elapsed}ms, it should not wait for the mesh timeout`)
+
+  await rejects(() => request('http://first.local', { dispatcher: agent }), {
+    message: 'No target found for first.local in thread 0.'
+  })
+})
+
+test('addRoute settles when the worker has already exited', async t => {
+  const dead = new Worker('', { eval: true })
+  await once(dead, 'exit')
+  strictEqual(dead.threadId, -1)
+
+  const interceptor = createThreadInterceptor({ domain: '.local' })
+
+  const start = Date.now()
+  await interceptor.route('dead', dead)
+  const elapsed = Date.now() - start
+
+  ok(elapsed < 2000, `route() took ${elapsed}ms, it should not hang on an exited worker`)
+
+  const agent = new Agent().compose(interceptor)
+
+  await rejects(() => request('http://dead.local', { dispatcher: agent }), {
+    message: 'No target found for dead.local in thread 0.'
+  })
+
+  await interceptor.close()
+})
+
+test('unroute is not blocked by a route pointing to an already exited worker', async t => {
+  const interceptor = createThreadInterceptor({ domain: '.local' })
+
+  await createStaleWorker(t, interceptor, 'stale')
+
+  const healthy = new Worker(join(__dirname, 'fixtures', 'worker1.js'))
+  t.after(() => healthy.terminate())
+  await interceptor.route('healthy', healthy)
+
+  const start = Date.now()
+  await interceptor.unroute('healthy', healthy)
+  const elapsed = Date.now() - start
+
+  ok(elapsed < 2000, `unroute() took ${elapsed}ms, it should not wait for the mesh timeout`)
+
+  await interceptor.close()
+})
+
+test('waitMessage resolves null when the target has already exited', async t => {
+  const dead = new Worker('', { eval: true })
+  await once(dead, 'exit')
+
+  strictEqual(isTargetGone(dead), true)
+
+  const start = Date.now()
+  const message = await waitMessage(dead, { timeout: 5000, description: 'MESSAGE_CLOSE' }, () => true)
+  const elapsed = Date.now() - start
+
+  strictEqual(message, null)
+  ok(elapsed < 2000, `waitMessage() took ${elapsed}ms, it should not arm the timer`)
+})


### PR DESCRIPTION
Fixes #203.

## Problem

`interceptor.close()` stalled for the full `meshTimeout` (5s), then rejected, when a route pointed at a `Worker` that had already exited.

Node.js emits `'exit'` on a `Worker` exactly once and then calls `removeAllListeners()` on it, so the listener `waitMessage()` attaches after the fact never fires. `waitMessage()` had no liveness check, which made "target already terminated" indistinguishable from "target is slow" — the timeout was the only reachable outcome. Two aggravating factors: the `await` sat inside the `for` loop, so N stale routes cost N × `meshTimeout`; and the rejection propagated out of the loop, so every route after the stale one was never sent `MESSAGE_CLOSE` at all.

Normally unreachable, since `addRoute()` installs an `'exit'`/`'close'` listener that removes the route — but reachable whenever a worker dies *before* that listener is attached.

## Fix

- **`lib/utils.js`** — new `kTerminated` symbol and `isTargetGone(target)` helper (`target[kTerminated] === true || target.threadId === -1`). `waitMessage()` resolves `null` immediately for a gone target instead of arming the timer.
- **`lib/common.js`** — `onClose()` records the terminal state on the port and fires/clears `port[kOnReadyHook]`, so a wire handshake pending on a dying target unblocks.
- **`lib/coordinator.js`** — `close()` posts `MESSAGE_CLOSE` to every route and awaits them with `Promise.allSettled`, so one unreachable target can no longer leave the rest of the mesh open; it rethrows the first rejection only after every other target had its chance. A port registered under multiple hostnames is now closed once. `addRoute()` skips already-gone targets rather than hanging forever on the handshake, and `removeThreadRoutes()` excludes gone ports from the acknowledgement set.

Existing `close()`/`unroute()` timeout semantics are unchanged — they still reject with the same message — so `test/wait-message-timeout.test.js` needed no edits.

## Verification

The reporter's repro, run against this branch:

```
before:  close() REJECTED after 5002ms — Timeout waiting for message from Worker (threadId: -1) [MESSAGE_CLOSE]
after:   close() RESOLVED after 0ms, addRoute(dead) settled: resolved
```

`test/exited-worker.test.js` adds 6 tests. Checked against unfixed `v1.x`: the two `close()` tests fail (5213ms and 1152ms) and the run then hangs forever on the `addRoute()`-on-a-dead-worker test — the three reported symptoms. (The multi-hostname dedupe test passes either way; it is coverage for the new behavior, not a regression guard.)

`npm run lint` clean. `npm run test:ci` passes: 136/138 (2 pre-existing skips) over 22 files, 98.83% statements / 99.75% branches.

## Note on v2

This does not affect `main`. I checked, and the bug does not reproduce there: v2 membership is worker-initiated, so a dead thread never creates a mesh entry; cleanup keys off the entangled `MessagePort`'s `'close'` rather than a one-shot `'exit'`; and both `Coordinator.close()` and `Interceptor.close()` are synchronous and never await a reply. This PR targets the v1.x line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PtQ5yYdo7p7aF8JQvurwt
