### PR TITLE
fix: close orphaned response body ports

### DIFF
--- a/lib/coordinator.js
+++ b/lib/coordinator.js
@@ -49,7 +49,17 @@ function onCoordinatorMessage (interceptor, port, url, message) {
         const { id, res, error } = message
 
         port[kInflightOutgoing].delete(id)
+        // The same port can be registered under more than one hostname, which
+        // attaches this listener once per hostname. Detach the response from the
+        // message, so the other invocations, which no longer find the request,
+        // do not mistake it for an orphaned one and close a port being read.
+        message.res = null
         inflight(error, res)
+      } else {
+        // The request is gone, it timed out while this response was in flight.
+        // Nobody will read the response body, so close its port: otherwise the
+        // sending side keeps it, and every chunk buffered behind it, alive.
+        message.res?.port?.close()
       }
 
       break

--- a/lib/dispatch-controller.js
+++ b/lib/dispatch-controller.js
@@ -32,6 +32,7 @@ class DispatchController extends EventEmitter {
   abort (reason) {
     this.#aborted = true
     this.#reason = reason
+    this.emit('abort', reason)
   }
 }
 

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -164,6 +164,7 @@ function createInterceptor (opts) {
             handler.onRequestStart(controller, {})
 
             if (controller.aborted) {
+              res.port?.close()
               handler.onResponseError(controller, controller.reason)
               return
             }
@@ -177,10 +178,12 @@ function createInterceptor (opts) {
               handler.onResponseError(controller, controller.reason)
               return
             }
-            /* c8 ignore next 6 */
+            /* c8 ignore next 8 */
           } catch (error) {
-            // No need to close the transferable port here, because it cannot happen
-            // for requests with a body
+            // Unlike the request body port, the response one is transferred
+            // based on the size of the response, so it can be open here even
+            // for a request that had no body at all.
+            res.port?.close()
             handler.onResponseError(controller, error)
             return
           }
@@ -198,6 +201,14 @@ function createInterceptor (opts) {
               body.pause()
             })
 
+            function onAbort (reason) {
+              // Tearing down the body notifies the sending side and closes the
+              // port, so the chunks buffered behind it can be released.
+              body.destroy(reason)
+            }
+
+            controller.on('abort', onAbort)
+
             body.on('data', function (chunk) {
               try {
                 handler.onResponseData(controller, chunk)
@@ -209,6 +220,10 @@ function createInterceptor (opts) {
             })
 
             body.on('end', function () {
+              // The body is complete: a later abort must not tear down a stream
+              // whose terminal event has already been delivered.
+              controller.removeListener('abort', onAbort)
+
               try {
                 handler.onResponseEnd(controller, [])
                 /* c8 ignore next 4 */

--- a/lib/message-port-streams.js
+++ b/lib/message-port-streams.js
@@ -2,6 +2,18 @@
 
 const { Writable, Readable, pipeline } = require('node:stream')
 
+// Destroy reasons come from the caller and are not always structured cloneable.
+// Forwarding one is best effort: a reason that cannot be cloned must not throw
+// out of _destroy, otherwise the port below is never closed and the other side
+// keeps the stream and its buffered chunks alive.
+function postControl (port, control) {
+  try {
+    port.postMessage(control)
+  } catch {
+    // The port is closed right after, and the other side reacts to that instead.
+  }
+}
+
 class MessagePortWritable extends Writable {
   #otherSideDestroyed = false
 
@@ -47,9 +59,9 @@ class MessagePortWritable extends Writable {
   _destroy (err, callback) {
     if (!this.#otherSideDestroyed) {
       if (err) {
-        this.messagePort.postMessage({ err })
+        postControl(this.messagePort, { err })
       } else {
-        this.messagePort.postMessage({ fin: true })
+        postControl(this.messagePort, { fin: true })
       }
     }
     setImmediate(() => {
@@ -113,7 +125,7 @@ class MessagePortReadable extends Readable {
 
   _destroy (err, callback) {
     if (err && !this.#otherSideDestroyed) {
-      this.messagePort.postMessage({ err })
+      postControl(this.messagePort, { err })
     }
     setImmediate(() => {
       this.messagePort.close()

--- a/lib/wire.js
+++ b/lib/wire.js
@@ -128,7 +128,17 @@ function onWireMessage (interceptor, port, message) {
         const { id, res, error } = message
 
         port[kInflightOutgoing].delete(id)
+        // The same port can be registered under more than one hostname, which
+        // attaches this listener once per hostname. Detach the response from the
+        // message, so the other invocations, which no longer find the request,
+        // do not mistake it for an orphaned one and close a port being read.
+        message.res = null
         inflight(error, res)
+      } else {
+        // The request is gone, it timed out while this response was in flight.
+        // Nobody will read the response body, so close its port: otherwise the
+        // sending side keeps it, and every chunk buffered behind it, alive.
+        message.res?.port?.close()
       }
 
       break

--- a/test/resilience.test.js
+++ b/test/resilience.test.js
@@ -1,0 +1,310 @@
+'use strict'
+
+const { test } = require('node:test')
+const { strictEqual } = require('node:assert')
+const { Readable } = require('node:stream')
+const { MessageChannel } = require('node:worker_threads')
+const { createThreadInterceptor, wire } = require('../')
+const { MessagePortWritable } = require('../lib/message-port-streams')
+const {
+  MESSAGE_REQUEST,
+  MESSAGE_RESPONSE,
+  MESSAGE_ROUTE_ADD,
+  MESSAGE_ROUTE_ADDED,
+  MESSAGE_WIRE
+} = require('../lib/utils')
+
+const requestOpts = { origin: 'http://orphaned.local', path: '/', method: 'GET', headers: {} }
+
+// An orphaned port shows up as a promise that never settles, so every wait in
+// this file has a deadline: an unbounded await would turn a failure into a hang.
+function bounded (promise, description) {
+  let handle
+
+  const deadline = new Promise((resolve, reject) => {
+    handle = setTimeout(() => reject(new Error(`Timeout while waiting for ${description}`)), 2000)
+    handle.unref()
+  })
+
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(handle))
+}
+
+// The handler methods are invoked unconditionally, so all of them must exist.
+// They only ever hand what they observed back to the test: onResponseError is
+// called from inside the interceptor's own try block, so an assertion throwing
+// in there is caught and delivered back to onResponseError as a new error,
+// which reports the failure as a diff of a diff. The assertions live in the
+// tests below instead.
+function handler (overrides) {
+  return {
+    onRequestStart () {},
+    onResponseStart () {},
+    onResponseData () {},
+    onResponseEnd () {},
+    onResponseError () {},
+    ...overrides
+  }
+}
+
+// The response body is streamed from a source that never ends: the sending side
+// keeps buffering until the receiving side tears the port down, so the source
+// being destroyed is the observable proof that the teardown propagated.
+function orphanedBody (t) {
+  const source = new Readable({ read () {} })
+  source.push('never delivered')
+
+  // The teardown destroys the source with an error: swallow it and observe
+  // 'close', which is emitted on both the error and the plain close path.
+  source.on('error', () => {})
+
+  // A failing subtest would otherwise leave its orphaned channel open, which
+  // keeps the event loop alive and turns a red subtest into a hanging one.
+  t.after(() => source.destroy())
+
+  const closed = new Promise(resolve => source.once('close', resolve))
+  const transferable = MessagePortWritable.asTransferable({ body: source })
+
+  return { sourceClosed: bounded(closed, 'the response body source to be torn down'), transferable }
+}
+
+// A peer that speaks just enough of the mesh protocol to be routable: it answers
+// the wire handshake and disposes of the loopback channels that are opened for a
+// thread registered under its own hostname.
+function meshPeer (t, port) {
+  const received = []
+  const waiting = []
+
+  port.on('message', message => {
+    if (message.type === MESSAGE_WIRE) {
+      port.postMessage({ type: MESSAGE_WIRE, ready: true, address: null })
+    } else if (message.type === MESSAGE_ROUTE_ADD) {
+      message.port.close()
+      port.postMessage({ type: MESSAGE_ROUTE_ADDED, threadId: message.threadId })
+    } else if (message.type === MESSAGE_REQUEST) {
+      const waiter = waiting.shift()
+
+      if (waiter) {
+        waiter(message)
+      } else {
+        received.push(message)
+      }
+    }
+  })
+
+  t.after(() => port.close())
+
+  return {
+    nextRequest () {
+      if (received.length > 0) {
+        return Promise.resolve(received.shift())
+      }
+
+      return bounded(new Promise(resolve => waiting.push(resolve)), 'the request to reach the peer')
+    },
+    respondWith (id, transferable) {
+      port.postMessage(
+        { type: MESSAGE_RESPONSE, id, res: { statusCode: 200, headers: {}, port: transferable.port } },
+        transferable.transferList
+      )
+    }
+  }
+}
+
+// A coordinator thread: its routes dispatch the inbound responses in
+// lib/coordinator.js.
+async function coordinatorMesh (t, timeout, alias) {
+  const channel = new MessageChannel()
+  const peer = meshPeer(t, channel.port2)
+
+  const interceptor = createThreadInterceptor({ domain: '.local', timeout, meshTimeout: 1000 })
+  t.after(() => channel.port1.close())
+
+  await bounded(interceptor.route('orphaned', channel.port1), 'the wire handshake')
+
+  if (alias) {
+    await bounded(interceptor.route(alias, channel.port1), 'the wire handshake of the second hostname')
+  }
+
+  return { dispatch: interceptor(() => false), peer }
+}
+
+// A wired thread: its routes dispatch the inbound responses in lib/wire.js,
+// which carries a second copy of the same handling. A fix applied to only one of
+// the two leaves the other one leaking.
+async function wiredMesh (t, timeout) {
+  const parent = new MessageChannel()
+  const route = new MessageChannel()
+  const peer = meshPeer(t, route.port2)
+
+  // wire() composes the global dispatcher of this thread, which is harmless
+  // here: every request below is dispatched explicitly.
+  const { interceptor } = wire({ port: parent.port2, domain: '.local', timeout })
+  t.after(() => {
+    parent.port1.close()
+    parent.port2.close()
+  })
+
+  const routed = bounded(
+    new Promise(resolve => {
+      parent.port1.on('message', message => {
+        if (message.type === MESSAGE_ROUTE_ADDED) {
+          resolve()
+        }
+      })
+    }),
+    'the route to be registered in the wired thread'
+  )
+
+  parent.port1.postMessage(
+    {
+      type: MESSAGE_ROUTE_ADD,
+      url: 'orphaned.local',
+      port: route.port1,
+      ready: true,
+      address: null,
+      threadId: 42
+    },
+    [route.port1]
+  )
+
+  await routed
+
+  return { dispatch: interceptor(() => false), peer }
+}
+
+// A delivered response carries a body port that its reader owns: the checks
+// above must not reach for it.
+function deliveredBody (t) {
+  const source = new Readable({ read () {} })
+  source.push('the response body')
+  source.push(null)
+  t.after(() => source.destroy())
+
+  return MessagePortWritable.asTransferable({ body: source })
+}
+
+async function lateResponseHasNoConsumer (t, createMesh) {
+  const { dispatch, peer } = await createMesh(t, 100)
+
+  const timedOut = Promise.withResolvers()
+  dispatch({ ...requestOpts }, handler({
+    onResponseError (controller, error) {
+      timedOut.resolve(error)
+    }
+  }))
+
+  const request = await peer.nextRequest()
+
+  // Waiting for the timeout first is what leaves the response without a
+  // consumer: it is the timeout that drops the inflight entry.
+  const error = await bounded(timedOut.promise, 'the request to time out')
+  strictEqual(error.message, 'Timeout while waiting from a response from orphaned.local')
+
+  const { sourceClosed, transferable } = orphanedBody(t)
+  peer.respondWith(request.id, transferable)
+  await sourceClosed
+}
+
+test('closes orphaned response body ports so the sender can release buffered data', async t => {
+  await t.test('a response that arrives after the request timed out has no consumer', async t => {
+    await lateResponseHasNoConsumer(t, coordinatorMesh)
+    await lateResponseHasNoConsumer(t, wiredMesh)
+  })
+
+  await t.test('a response for a request that was aborted before the body started', async t => {
+    const { dispatch, peer } = await coordinatorMesh(t)
+
+    const aborted = Promise.withResolvers()
+    dispatch({ ...requestOpts }, handler({
+      onRequestStart (controller) {
+        controller.abort(new Error('aborted before response'))
+      },
+      onResponseError (controller, error) {
+        aborted.resolve(error)
+      }
+    }))
+
+    const request = await peer.nextRequest()
+
+    const { sourceClosed, transferable } = orphanedBody(t)
+    peer.respondWith(request.id, transferable)
+    await sourceClosed
+    const error = await bounded(aborted.promise, 'the abort to reach the handler')
+    strictEqual(error.message, 'aborted before response')
+  })
+
+  await t.test('an abort while the body is streaming tears the stream down', async t => {
+    const { dispatch, peer } = await coordinatorMesh(t)
+
+    const errored = Promise.withResolvers()
+    dispatch({ ...requestOpts }, handler({
+      onResponseData (controller) {
+        controller.abort(new Error('aborted mid-stream'))
+      },
+      onResponseError (controller, error) {
+        errored.resolve(error)
+      }
+    }))
+
+    const request = await peer.nextRequest()
+
+    const { sourceClosed, transferable } = orphanedBody(t)
+    peer.respondWith(request.id, transferable)
+    const error = await bounded(errored.promise, 'the abort to reach the handler')
+    strictEqual(error.message, 'aborted mid-stream')
+    await sourceClosed
+  })
+
+  await t.test('an abort with a reason that cannot be structured-cloned', async t => {
+    const { dispatch, peer } = await coordinatorMesh(t)
+
+    // Abort reasons come from the caller: failing to forward one over the port
+    // must not leave the port, and the body buffered behind it, alive. The error
+    // the handler receives is deliberately not asserted, it is the one the
+    // failed clone produces until the reason can be forwarded again.
+    const reason = new Error('aborted with an unclonable reason', { cause: { notCloneable: () => {} } })
+    const errored = Promise.withResolvers()
+    dispatch({ ...requestOpts }, handler({
+      onResponseData (controller) {
+        controller.abort(reason)
+      },
+      onResponseError () {
+        errored.resolve()
+      }
+    }))
+
+    const request = await peer.nextRequest()
+
+    const { sourceClosed, transferable } = orphanedBody(t)
+    peer.respondWith(request.id, transferable)
+    await bounded(errored.promise, 'the abort to reach the handler')
+    await sourceClosed
+  })
+})
+
+test('a delivered response keeps its body port when the target has a second hostname', async t => {
+  // Registering the same port under a second hostname attaches the inbound
+  // response handling once per hostname: only the first invocation finds the
+  // request, and the others must leave the body port to the reader.
+  const { dispatch, peer } = await coordinatorMesh(t, undefined, 'aliased')
+
+  const chunks = []
+  const ended = Promise.withResolvers()
+  dispatch({ ...requestOpts }, handler({
+    onResponseData (controller, chunk) {
+      chunks.push(chunk.toString())
+    },
+    onResponseEnd () {
+      ended.resolve()
+    },
+    onResponseError (controller, error) {
+      ended.reject(error)
+    }
+  }))
+
+  const request = await peer.nextRequest()
+  peer.respondWith(request.id, deliveredBody(t))
+
+  await bounded(ended.promise, 'the response body to be delivered')
+  strictEqual(chunks.join(''), 'the response body')
+})


### PR DESCRIPTION
Backport of #202 to the 1.x line, as requested there.

## Why it is not a straight port

The defect is the same one #202 describes: a response body that is not inlined travels over a dedicated MessagePort, and when the response ends up with no consumer nothing closes that port, so the sending side keeps it and every chunk buffered behind it alive. The memory sits off the V8 heap, which is why heap based monitoring never sees it.

The 1.x code differs enough that three of the sites are not the ones in #202:

1. **The inbound response is dispatched in two places on this line**, `lib/coordinator.js` and `lib/wire.js`, and both dropped the message the same way. On main these two collapsed into `#onPeerMessage`, so the v2 fix has a single site where 1.x needs two.
2. **The comment in the `catch` around `onResponseStart` said the transferable port cannot leak there** because it cannot happen for requests with a body. That reasoning is about the *request* body port, which only exists for a request with a stream body. The port stranded at that point is the *response* one, transferred on the size of the response alone, so it can be open even for a request that had no body at all.
3. **A route port can be registered under more than one hostname**, which attaches the response handling once per hostname. Closing an orphaned port from that handler is therefore not enough on its own: without detaching the delivered response from the message, the remaining invocations no longer find the request, mistake the response for an orphaned one and close a port that is being read. There is a dedicated regression test for this, and it is the only one of the new tests that also passes against unpatched code, which is the point of it.

## The fix

`lib/coordinator.js` and `lib/wire.js`: when a response arrives with no matching inflight entry, close its body port. When it does match, detach it from the message first, so a second invocation for another hostname cannot close a live port.

`lib/interceptor.js`: close the response port in the `controller.aborted` branch and in the `catch` branch, and destroy the body stream when the request is aborted while the body is streaming. The destroy notifies the sending side through the existing control message and closes the port, so the sender's pipeline tears down the source stream and releases the buffered data.

`lib/dispatch-controller.js`: `DispatchController` already extends `EventEmitter` and already emits `pause` and `resume` for the body, so `abort` travels the same way and the interceptor destroys the body stream when it arrives. The listener is removed once the body ends, so a late abort cannot deliver an `onResponseError` after `onResponseEnd`.

`lib/message-port-streams.js`: `_destroy` posted the control message before scheduling the port close, so a reason that cannot be structured cloned threw and the close never happened. Abort reasons come from the caller, which makes that reachable from the path above and would have reintroduced the very leak this fixes. Forwarding the reason is best effort now; the port is closed either way and the other side reacts to the close instead.

No behavior change for consumed responses.

## Tests

One new file, `test/resilience.test.js`, built on the same fake peer harness idea used for v2 and adapted to this line. Six tests: the four orphaning scenarios (late response after the request timed out, abort before the body starts, abort mid stream, abort with a reason that cannot be structured cloned) plus the multi hostname regression described above.

The assertion is on the sending side: the source `Readable` behind `MessagePortWritable.asTransferable` must be destroyed, which proves the teardown propagated across the port and the buffered data was actually released.

Suite goes from 138 to 144 tests, no failures, the same 2 skips as before. Lint clean.

Coverage of the fix was checked by reverting each production file to its unpatched state one at a time and running only the new file: every one of the five files turns it red, so no hunk is dead weight.

## Effect in production

Measured on the v2 equivalent and reported in full on #202. Short version: our gateway service grew external memory at roughly 48 MB/min under load, kept growing after traffic stopped, heap flat throughout, ending in a container OOM kill. With the fix, post traffic growth disappeared entirely and the process wide MessagePort count returned to its baseline within two minutes of stopping instead of staying stuck.

We have been running the equivalent change on 1.4.0 as a local pnpm patch since then. `git diff v1.4.0 v1.5.0` touches only workflows, `.gitignore` and the manifests, so the library code is byte identical across the two and this applies unchanged to 1.5.x. Shipping it as a 1.5.1 would let current `@platformatic/runtime` users pick it up without waiting for the v2 migration.
